### PR TITLE
Remove duplicate port definition

### DIFF
--- a/rtl/verilog/rl_ram_1r1w_lattice.sv
+++ b/rtl/verilog/rl_ram_1r1w_lattice.sv
@@ -117,7 +117,6 @@ module rl_ram_1r1w_lattice #(
     .RdClock              ( clk_i           ),
     .RdClockEn            ( 1'b1            ),
     .RdAddress            ( raddr_i         ),
-    .RdClock              ( clk_i           ),
     .Q                    ( dout_o          ) );
  
 endmodule


### PR DESCRIPTION
RdClock is declared twice and causes synthesis to fail - removed dupicate definition